### PR TITLE
Add SublimeLinter required scopes to prevent it from changing color scheme

### DIFF
--- a/cobalt2.tmTheme
+++ b/cobalt2.tmTheme
@@ -582,6 +582,17 @@
     </dict>
     <dict>
         <key>name</key>
+        <string>SublimeLinter Error</string>
+        <key>scope</key>
+        <string>sublimelinter.mark.error</string>
+        <key>settings</key>
+        <dict>
+            <key>foreground</key>
+            <string>#DA2000</string>
+        </dict>
+    </dict>
+    <dict>
+        <key>name</key>
         <string>SublimeLinter Error Outline</string>
         <key>scope</key>
         <string>sublimelinter.outline.illegal</string>
@@ -602,6 +613,28 @@
         <dict>
             <key>background</key>
             <string>#FF0000</string>
+        </dict>
+    </dict>
+    <dict>
+        <key>name</key>
+        <string>SublimeLinter Gutter Mark</string>
+        <key>scope</key>
+        <string>sublimelinter.gutter-mark</string>
+        <key>settings</key>
+        <dict>
+            <key>foreground</key>
+            <string>#FFFFFF</string>
+        </dict>
+    </dict>
+    <dict>
+        <key>name</key>
+        <string>SublimeLinter Warning</string>
+        <key>scope</key>
+        <string>sublimelinter.mark.warning</string>
+        <key>settings</key>
+        <dict>
+            <key>foreground</key>
+            <string>#EDBA00</string>
         </dict>
     </dict>
     <dict>


### PR DESCRIPTION
This would resolve https://github.com/SublimeLinter/SublimeLinter3/issues/283 and hopefully make developing this great SL theme with the help of SublimeLinter.


:beers: