### PR TITLE
Transient tabs are now recognisable, thanks to a transparent bg

### DIFF
--- a/Cobalt2.sublime-theme
+++ b/Cobalt2.sublime-theme
@@ -50,6 +50,12 @@
         "attributes": ["selected"],
         "layer0.texture": "Theme - Cobalt2/Cobalt2/tab-active.png"
     },
+    // Tab transient state
+    {
+        "class": "tab_control",
+        "attributes": ["transient"],
+        "layer0.opacity": 0.1
+    },
     // Tab dirty state (close button hidden)
     {
         "class": "tab_control",
@@ -208,6 +214,19 @@
         "parents": [{"class": "tab_control", "attributes": ["selected"]}],
         "fg": [230, 230, 230],
         "shadow_color": [35, 35, 35]
+    },
+    // Transient tab label, when not selected
+    {
+        "class": "tab_label",
+        "attributes": ["transient"],
+        "fg": [140, 140, 140]
+    },
+    // Transient tab label, when selected
+    {
+        "class": "tab_label",
+        "attributes": ["transient"],
+        "parents": [{"class": "tab_control", "attributes": ["selected"]}],
+        "fg": [230, 230, 230]
     },
 
 //


### PR DESCRIPTION
Closes #81, if @wesbos approves the "transparent" look and feel:

![Transient Tab](https://cloud.githubusercontent.com/assets/1799710/10262705/a390689e-69d3-11e5-9519-be3b81278cb1.png)
![Transient Tab Selected](https://cloud.githubusercontent.com/assets/1799710/10262706/a3992f56-69d3-11e5-832f-b6e3508e232a.png)
![Open Tab and Transient Tab](https://cloud.githubusercontent.com/assets/1799710/10262707/a3a025c2-69d3-11e5-85d7-346e48e2f6a4.png)
