### PR TITLE
Addresses the BEM Modifier Invalid HTML Comment

### DIFF
--- a/cobalt2.tmTheme
+++ b/cobalt2.tmTheme
@@ -905,6 +905,21 @@
         <string>#ffc600</string>
       </dict>
     </dict>
+    
+    <dict>
+      <key>name</key>
+      <string>BEM Modifier Invalid HTML Comment</string>
+      <key>scope</key>
+      <string>invalid.illegal.bad-comments-or-CDATA.html</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#0088FF</string>
+        <key>background</key>
+        <string>#17344A</string>
+      </dict>
+    </dict>
+
 
   </array>
   <key>uuid</key>


### PR DESCRIPTION
BEM modifier hyphens in an HTML comment will lead to an invalid comment but the colors will be set as normal comment's colors.

Before
![b](https://i.imgur.com/G2NR0Cv.png)

After
![a](https://i.imgur.com/MwPYB1L.png)