### PR TITLE
Re-enable highlighting of bad HTML comments.

### DIFF
--- a/cobalt2.tmTheme
+++ b/cobalt2.tmTheme
@@ -905,21 +905,6 @@
         <string>#ffc600</string>
       </dict>
     </dict>
-    
-    <dict>
-      <key>name</key>
-      <string>BEM Modifier Invalid HTML Comment</string>
-      <key>scope</key>
-      <string>invalid.illegal.bad-comments-or-CDATA.html</string>
-      <key>settings</key>
-      <dict>
-        <key>foreground</key>
-        <string>#0088FF</string>
-        <key>background</key>
-        <string>#17344A</string>
-      </dict>
-    </dict>
-
 
   </array>
   <key>uuid</key>


### PR DESCRIPTION
This reverts #86.

I was getting ready to pull the recent(-ish) tmTheme changes into cobalt2-atom and noticed the change in #86.

`<!-- foo -- bar -->` is in fact a bad HTML comment due to the "--" in the middle. See http://www.w3.org/TR/html5/syntax.html#comments:
>Following this sequence, the comment may have text, with the additional restriction that the text must not ... nor contain two consecutive U+002D HYPHEN-MINUS characters (--) ...