### PR TITLE
Updated JavaScript class name and object key scopes

### DIFF
--- a/cobalt2.tmTheme
+++ b/cobalt2.tmTheme
@@ -930,7 +930,10 @@
      <key>name</key>
      <string>Extends</string>
      <key>scope</key>
-     <string>storage.type.extends.js</string>
+     <string>
+      , storage.type.extends.js,
+      , storage.modifier.extends.js,
+     </string>
      <key>settings</key>
      <dict>
        <key>fontStyle</key>

--- a/cobalt2.tmTheme
+++ b/cobalt2.tmTheme
@@ -692,7 +692,10 @@
         <key>name</key>
         <string>PHP class name</string>
         <key>scope</key>
-        <string>entity.name.type.class.php</string>
+        <string>
+          , entity.name.class.php, 
+          , entity.name.type.class.php,
+        </string>
         <key>settings</key>
         <dict>
             <key>foreground</key>
@@ -882,8 +885,9 @@
      <string>Object Keys</string>
      <key>scope</key>
      <string>
-      , string.unquoted.label.js,
-    </string>
+      , string.unquoted.label.js, 
+      , meta.object-literal.key.js -string,
+     </string>
      <key>settings</key>
      <dict>
        <key>foreground</key>
@@ -899,7 +903,10 @@
      <key>name</key>
      <string>Class Name</string>
      <key>scope</key>
-     <string>entity.name.class.js</string>
+     <string>
+      , entity.name.class.js, 
+      , entity.name.type.class.js,
+     </string>
      <key>settings</key>
      <dict>
        <key>foreground</key>


### PR DESCRIPTION
This update allows the recently added styles for JavaScript class names
and unquoted object keys to work with the JavaScript syntax that ships
with the latest versions of Sublime Text. The scopes used to style PHP
class names was also updated, for the same reason.