### PR TITLE
Fix docblock issue where storage modifier words are not correct color

### DIFF
--- a/cobalt2.tmTheme
+++ b/cobalt2.tmTheme
@@ -123,7 +123,7 @@
       <key>name</key>
       <string>Comment</string>
       <key>scope</key>
-      <string>comment</string>
+      <string>comment, comment.block.documentation.phpdoc.php storage.modifier.php</string>
       <key>settings</key>
       <dict>
         <key>fontStyle</key>

--- a/test/issue/color_scheme_test_98.php
+++ b/test/issue/color_scheme_test_98.php
@@ -1,0 +1,28 @@
+<?php // COLOR SCHEME TEST "Theme - Cobalt2/cobalt2.tmTheme" "PHP"
+
+class x
+{
+    /**
+     * @param array
+//              ^ fg=#0088ff fs=italic
+     * @param bool
+//              ^ fg=#0088ff fs=italic
+     * @param int
+//              ^ fg=#0088ff fs=italic
+     * @param public
+//              ^ fg=#0088ff fs=italic
+     * @param protected
+//              ^ fg=#0088ff fs=italic
+     * @param private
+//              ^ fg=#0088ff fs=italic
+     * @access private
+//              ^ fg=#0088ff fs=italic
+     * @access protected
+//              ^ fg=#0088ff fs=italic
+     * @access public
+//              ^ fg=#0088ff fs=italic
+     */
+    public function y()
+    {
+    }
+}


### PR DESCRIPTION
For example, the second parameter in the following should all be the
same colour:

```
/**
 * @param array
 * @param public
 * @access public
 */
```

Resolves #98
