### PR TITLE
Fixed typo, wrong URL for ES6 course

### DIFF
--- a/messages/hello.txt
+++ b/messages/hello.txt
@@ -14,7 +14,7 @@ Many new things have been added, including:
 - autocomplete, goto anything and command palette refinements
 
 🔥📖 I wrote a book + video series on Sublime Text! → SublimeTextBook.com
-🔥📼 An a Premium training course on ES6 → ReactForBeginners.com
+🔥📼 And a Premium training course on ES6 → ES6.io
 🔥📼 And I created a Training series on React.js → ReactForBeginners.com
 
 Use the coupon code COBALT2 for $15 off 💰 💵


### PR DESCRIPTION
Change "An" to "And", correct URL for ES6 course (was pointing to React course before)