### PR TITLE
Fix string color inside quotes in vscode

### DIFF
--- a/cobalt2.tmTheme
+++ b/cobalt2.tmTheme
@@ -218,7 +218,7 @@
       <key>name</key>
       <string>String embedded-source</string>
       <key>scope</key>
-      <string>string.quoted source</string>
+      <string>string.quoted source, string.quoted</string>
       <key>settings</key>
       <dict>
         <key>fontStyle</key>


### PR DESCRIPTION
fix [issue 138](https://github.com/wesbos/cobalt2/issues/138)