### PR TITLE
Fix Template Literals and cleanup some scopes

### DIFF
--- a/cobalt2.tmTheme
+++ b/cobalt2.tmTheme
@@ -681,8 +681,8 @@
         <string>PHP class name</string>
         <key>scope</key>
         <string>
-          , entity.name.class.php,
-          , entity.name.type.class.php,
+          entity.name.class.php,
+          entity.name.type.class.php,
         </string>
         <key>settings</key>
         <dict>
@@ -846,13 +846,13 @@
       <key>name</key>
       <string>JavaScript Function</string>
       <key>scope</key>
-      <string>storage.type.function.js </string>
+      <string>storage.type.function.js</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#ffa5f3</string>
+        <string>#FFA5F3</string>
         <key>background</key>
-        <string>#1d3c52</string>
+        <string>#1D3C52</string>
       </dict>
     </dict>
 
@@ -864,7 +864,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#2eff00</string>
+        <string>#2EFF00</string>
       </dict>
     </dict>
 
@@ -872,16 +872,65 @@
      <key>name</key>
      <string>Object Keys</string>
      <key>scope</key>
-     <string>
-      , string.unquoted.label.js,
-      , meta.object-literal.key.js -string,
-     </string>
+     <string>string.unquoted.label.js, meta.object-literal.key.js -string</string>
      <key>settings</key>
      <dict>
        <key>foreground</key>
        <string>#2AFFDF</string>
      </dict>
    </dict>
+
+  <dict>
+    <key>name</key>
+    <string>Template Literals - ticks</string>
+    <key>scope</key>
+    <string>template.begin, template.end</string>
+    <key>settings</key>
+    <dict>
+      <key>foreground</key>
+      <string>#2EFF00</string>
+    </dict>
+  </dict>
+
+  <dict>
+    <key>name</key>
+    <string>Template Literals - words</string>
+    <key>scope</key>
+    <string>template</string>
+    <key>settings</key>
+    <dict>
+      <key>foreground</key>
+      <string>#9EFF80</string>
+    </dict>
+  </dict>
+
+  <dict>
+    <key>name</key>
+    <string>Template Literals - expressions</string>
+    <key>scope</key>
+    <string>
+      template.expression.punctuation.begin,
+      template.expression.punctuation.end,
+      template.expression.brace,
+    </string>
+    <key>settings</key>
+    <dict>
+      <key>foreground</key>
+      <string>#FFFFFF</string>
+    </dict>
+  </dict>
+
+  <dict>
+    <key>name</key>
+    <string>Template Literals - functions</string>
+    <key>scope</key>
+    <string>template.entity</string>
+    <key>settings</key>
+    <dict>
+      <key>foreground</key>
+      <string>#FFC600</string>
+    </dict>
+  </dict>
 
   <!--
     ES6 Classes
@@ -892,8 +941,8 @@
      <string>Class Name</string>
      <key>scope</key>
      <string>
-      , entity.name.class.js,
-      , entity.name.type.class.js,
+      entity.name.class.js,
+      entity.name.type.class.js,
      </string>
      <key>settings</key>
      <dict>
@@ -919,8 +968,8 @@
      <string>Extends</string>
      <key>scope</key>
      <string>
-      , storage.type.extends.js,
-      , storage.modifier.extends.js,
+      storage.type.extends.js,
+      storage.modifier.extends.js,
      </string>
      <key>settings</key>
      <dict>
@@ -963,10 +1012,10 @@
       <string>Markdown Punctuation</string>
       <key>scope</key>
       <string>
-        , punctuation.definition.list_item.markdown,
-        , punctuation.definition.blockquote.markdown,
-        , punctuation.definition.string.begin.markdown,
-        , punctuation.definition.string.end.markdown,
+        punctuation.definition.list_item.markdown,
+        punctuation.definition.blockquote.markdown,
+        punctuation.definition.string.begin.markdown,
+        punctuation.definition.string.end.markdown,
       </string>
       <key>settings</key>
       <dict>
@@ -980,7 +1029,7 @@
       <string>Markdown Punctuation</string>
       <key>scope</key>
       <string>
-        , markup.underline.link.image.markdown,
+        markup.underline.link.image.markdown,
       </string>
       <key>settings</key>
       <dict>
@@ -1001,14 +1050,14 @@
       <string>Italic HTML attribute names</string>
       <key>scope</key>
       <string>
-        , entity.other.attribute-name.html,
-        , entity.other.attribute-name.event.html,
-        , entity.other.attribute-name.class.html,
-        , entity.other.attribute-name.style.html,
-        , entity.other.attribute-name.id.html,
-        , entity.other.attribute-name.tag.jade,
-        , constant.other.symbol.ruby,
-        , entity.other.attribute-name.jsx,
+        entity.other.attribute-name.html,
+        entity.other.attribute-name.event.html,
+        entity.other.attribute-name.class.html,
+        entity.other.attribute-name.style.html,
+        entity.other.attribute-name.id.html,
+        entity.other.attribute-name.tag.jade,
+        constant.other.symbol.ruby,
+        entity.other.attribute-name.jsx,
       </string>
       <key>settings</key>
       <dict>

--- a/cobalt2.tmTheme
+++ b/cobalt2.tmTheme
@@ -925,7 +925,10 @@
     <key>name</key>
     <string>Template Literals - ticks</string>
     <key>scope</key>
-    <string>template.begin, template.end</string>
+    <string>
+      , template.begin,
+      , template.end,
+    </string>
     <key>settings</key>
     <dict>
       <key>foreground</key>

--- a/cobalt2.tmTheme
+++ b/cobalt2.tmTheme
@@ -871,7 +871,10 @@
      <key>name</key>
      <string>Object Keys</string>
      <key>scope</key>
-     <string>string.unquoted.label.js, meta.object-literal.key.js -string</string>
+     <string>
+       , string.unquoted.label.js,
+       , meta.object-literal.key.js -string,
+     </string>
      <key>settings</key>
      <dict>
        <key>foreground</key>

--- a/cobalt2.tmTheme
+++ b/cobalt2.tmTheme
@@ -161,7 +161,6 @@
         <string>#CCCCCC</string>
         <key>background</key>
         <string>#0d3a58</string>
-
       </dict>
     </dict>
     <dict>
@@ -681,8 +680,8 @@
         <string>PHP class name</string>
         <key>scope</key>
         <string>
-          entity.name.class.php,
-          entity.name.type.class.php,
+          , entity.name.class.php,
+          , entity.name.type.class.php,
         </string>
         <key>settings</key>
         <dict>
@@ -909,9 +908,9 @@
     <string>Template Literals - expressions</string>
     <key>scope</key>
     <string>
-      string.template.expression.punctuation.begin,
-      string.template.expression.punctuation.end,
-      string.template.expression.brace,
+      , string.template.expression.punctuation.begin,
+      , string.template.expression.punctuation.end,
+      , string.template.expression.brace,
     </string>
     <key>settings</key>
     <dict>
@@ -955,8 +954,8 @@
      <string>Class Name</string>
      <key>scope</key>
      <string>
-      entity.name.class.js,
-      entity.name.type.class.js,
+      , entity.name.class.js,
+      , entity.name.type.class.js,
      </string>
      <key>settings</key>
      <dict>
@@ -982,8 +981,8 @@
      <string>Extends</string>
      <key>scope</key>
      <string>
-      storage.type.extends.js,
-      storage.modifier.extends.js,
+      , storage.type.extends.js,
+      , storage.modifier.extends.js,
      </string>
      <key>settings</key>
      <dict>
@@ -1026,10 +1025,10 @@
       <string>Markdown Punctuation</string>
       <key>scope</key>
       <string>
-        punctuation.definition.list_item.markdown,
-        punctuation.definition.blockquote.markdown,
-        punctuation.definition.string.begin.markdown,
-        punctuation.definition.string.end.markdown,
+        , punctuation.definition.list_item.markdown,
+        , punctuation.definition.blockquote.markdown,
+        , punctuation.definition.string.begin.markdown,
+        , punctuation.definition.string.end.markdown,
       </string>
       <key>settings</key>
       <dict>
@@ -1042,9 +1041,7 @@
       <key>name</key>
       <string>Markdown Punctuation</string>
       <key>scope</key>
-      <string>
-        markup.underline.link.image.markdown,
-      </string>
+      <string>markup.underline.link.image.markdown</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>
@@ -1064,14 +1061,14 @@
       <string>Italic HTML attribute names</string>
       <key>scope</key>
       <string>
-        entity.other.attribute-name.html,
-        entity.other.attribute-name.event.html,
-        entity.other.attribute-name.class.html,
-        entity.other.attribute-name.style.html,
-        entity.other.attribute-name.id.html,
-        entity.other.attribute-name.tag.jade,
-        constant.other.symbol.ruby,
-        entity.other.attribute-name.jsx,
+        , entity.other.attribute-name.html,
+        , entity.other.attribute-name.event.html,
+        , entity.other.attribute-name.class.html,
+        , entity.other.attribute-name.style.html,
+        , entity.other.attribute-name.id.html,
+        , entity.other.attribute-name.tag.jade,
+        , constant.other.symbol.ruby,
+        , entity.other.attribute-name.jsx,
       </string>
       <key>settings</key>
       <dict>

--- a/cobalt2.tmTheme
+++ b/cobalt2.tmTheme
@@ -909,9 +909,9 @@
     <string>Template Literals - expressions</string>
     <key>scope</key>
     <string>
-      template.expression.punctuation.begin,
-      template.expression.punctuation.end,
-      template.expression.brace,
+      string.template.expression.punctuation.begin,
+      string.template.expression.punctuation.end,
+      string.template.expression.brace,
     </string>
     <key>settings</key>
     <dict>
@@ -929,6 +929,20 @@
     <dict>
       <key>foreground</key>
       <string>#FFC600</string>
+    </dict>
+  </dict>
+    
+  <dict>
+    <key>name</key>
+    <string>Template Literals - language</string>
+    <key>scope</key>
+    <string>template.variable.language</string>
+    <key>settings</key>
+    <dict>
+      <key>fontStyle</key>
+      <string></string>
+      <key>foreground</key>
+      <string>#FF80E1</string>
     </dict>
   </dict>
 


### PR DESCRIPTION
Lets template literals be highlighted correctly in VS Code (and probably Atom):  

![2017-01-03 16_00_35- alert-conditions js - omneo-ui - visual studio code](https://cloud.githubusercontent.com/assets/1449779/21622897/ce26a7b8-d1cd-11e6-9ef6-1d5f07baa18f.png)

Also cleans up some scope selectors with double commas and normalizes colors being in both lowercase and uppercase variants